### PR TITLE
Adding SDRPlay RSP2 support through native API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,16 @@ export DEBUG ?= 0
 export USE_STATSD ?= 0
 export WITH_RTLSDR ?= 1
 export WITH_MIRISDR ?= 0
+export WITH_SDRPLAY ?= 0
 CC = gcc
 CFLAGS = -std=c99 -g -Wall -O3 -fno-omit-frame-pointer -ffast-math -D_XOPEN_SOURCE=500 -DDEBUG=$(DEBUG)
 DUMPVDL2_VERSION:=\"$(shell git describe --always --tags --dirty)\"
 ifneq ($(DUMPVDL2_VERSION), \"\")
   CFLAGS+=-DDUMPVDL2_VERSION=$(DUMPVDL2_VERSION)
 endif
+
 CFLAGS += -Iasn1
-CFLAGS += -DUSE_STATSD=$(USE_STATSD) -DWITH_RTLSDR=$(WITH_RTLSDR) -DWITH_MIRISDR=$(WITH_MIRISDR)
+CFLAGS += -DUSE_STATSD=$(USE_STATSD) -DWITH_RTLSDR=$(WITH_RTLSDR) -DWITH_SDRPLAY=$(WITH_SDRPLAY) -DWITH_MIRISDR=$(WITH_MIRISDR)
 CFLAGS += `pkg-config --cflags glib-2.0`
 LDLIBS = -lm
 LDLIBS += `pkg-config --libs glib-2.0`
@@ -51,6 +53,10 @@ ifeq ($(WITH_MIRISDR), 1)
   DEPS += mirisdr.o
   LDLIBS += -lmirisdr
 endif
+ifeq ($(WITH_SDRPLAY), 1)
+  DEPS += sdrplay.o
+  LDLIBS += -lmirsdrapi-rsp
+endif
 
 .PHONY: all clean $(SUBDIRS) $(CLEANDIRS)
 
@@ -87,6 +93,8 @@ avlc.o: dumpvdl2.h avlc.h xid.h acars.h x25.h
 acars.o: dumpvdl2.h acars.h
 
 mirisdr.o: dumpvdl2.h mirisdr.h
+
+sdrplay.o: dumpvdl2.h sdrplay.h
 
 output.o: dumpvdl2.h
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ dumpvdl2 is a lightweight, standalone VDL Mode 2 message decoder and protocol an
 - Supports following SDR hardware:
   - RTLSDR (via [rtl-sdr library] (http://osmocom.org/projects/sdr/wiki/rtl-sdr))
   - Mirics SDR, eg. SDRPlay (via [libmirisdr-4] (https://github.com/f4exb/libmirisdr-4))
+  - SDRPlay RSP1/2, (Native support through API (http://www.sdrplay.com/docs/SDRplay_SDR_API_Specification.pdf))
   - reads prerecorded IQ data from file
 - Decodes up to 8 VDL2 channels simultaneously
 - Outputs messages to standard output or to a file (with optional daily or hourly file rotation)
@@ -61,6 +62,10 @@ Install `libmirisdr-4` library:
         sudo ldconfig
         sudo cp $HOME/libmirisdr-4/mirisdr.rules /etc/udev/rules.d/mirisdr.rules
 
+##### SDRPLAY RSP1/2 support
+
+Install `http://www.sdrplay.com/linuxdl.php` library.
+
 ##### Compiling dumpvdl2
 
 Clone the `dumpvdl2` repository:
@@ -79,6 +84,10 @@ Mirics support has to be explicitly enabled, like this:
 If you want Mirics only, you may disable RTLSDR support:
 
         make WITH_MIRISDR=1 WITH_RTLSDR=0
+
+If you want SDRPLAY RSP1/2 only, you may disable RTLSDR support:
+
+        make WITH_SDRPLAY=1 WITH_RTLSDR=0
 
 **Note:** every time you decide to recompile with different `WITH_*` or `USE_*` options,
 clean the old build first using `make clean`.
@@ -153,6 +162,13 @@ This switches USB transfer mode from isochronous to bulk, which is usually enoug
 this problem. If it does not help, it might be that your Pi is overloaded or not beefy enough
 for the task.
 
+##### SDRPLAY RSP1/2 Native
+
+ Sdrplay RSP native driver have some advanced option to support different antenna port, Bias-T, notch filter on AM/FM. 
+ A sample start with antenna A selection, bias-t off and notch filter :
+ 
+        ./dumpvdl2 --sdrplay 0 --gain 80 --antenna A --biast 0 --notch-filter 1 136975000 
+ 
 ### Output options
 
 - Decoded messages are printed to standard output by default. You can direct them to a

--- a/dumpvdl2.c
+++ b/dumpvdl2.c
@@ -30,6 +30,9 @@
 #if WITH_MIRISDR
 #include "mirisdr.h"
 #endif
+#if WITH_SDRPLAY
+#include "sdrplay.h"
+#endif
 #include "dumpvdl2.h"
 
 int do_exit = 0;
@@ -43,6 +46,9 @@ void sighandler(int sig) {
 #endif
 #if WITH_MIRISDR
 	mirisdr_cancel();
+#endif
+#if WITH_SDRPLAY
+	sdrplay_cancel();
 #endif
 }
 
@@ -115,6 +121,10 @@ void usage() {
 	fprintf(stderr, "MIRI-SDR receiver:\n");
 	fprintf(stderr, "\tdumpvdl2 [output_options] --mirisdr <device_id> [mirisdr_options] [<freq_1> [freq_2 [...]]]\n");
 #endif
+#if WITH_SDRPLAY
+	fprintf(stderr, "SDRPLAY RSP receiver:\n");
+	fprintf(stderr, "\tdumpvdl2 [output_options] --sdrplay <device_id> [sdrplay_options] [<freq_1> [freq_2 [...]]]\n");
+#endif
 	fprintf(stderr, "I/Q input from file:\n");
 	fprintf(stderr, "\tdumpvdl2 [output_options] --iq-file <input_file> [file_options] [<freq_1> [freq_2 [...]]]\n");
 	fprintf(stderr, "\ncommon options:\n");
@@ -145,6 +155,17 @@ void usage() {
 	fprintf(stderr, "\t--correction <correction>\tSet freq correction (in Hertz)\n");
 	fprintf(stderr, "\t--centerfreq <center_frequency>\tSet center frequency in Hz (default: auto)\n");
 	fprintf(stderr, "\t--usb-mode <usb_transfer_mode>\t0 - isochronous (default), 1 - bulk\n");
+#endif
+#if WITH_SDRPLAY
+	fprintf(stderr, "\nsdrplay_options:\n");
+	fprintf(stderr, "\t--sdrplay <device_id>\t\tUse SDRPLAY RSP device with specified ID or serial number (default: ID=0)\n");
+	fprintf(stderr, "\t--gain <gain>\t\t\tSet gain (in decibels, from 0 to 104 dB)\n");
+	fprintf(stderr, "\t--correction <correction>\tSet freq correction (ppm)\n");
+	fprintf(stderr, "\t--centerfreq <center_frequency>\tSet center frequency in Hz (default: auto)\n");
+	fprintf(stderr, "\t--antenna <A/B>\t\t\tA - Antenna port A (default), B - antenna port B\n");
+    fprintf(stderr, "\t--biast <power>\t\t\t0 - BiasT off (default), 1 - BiasT on\n");
+    fprintf(stderr, "\t--notch-filter <power>\t\t0 - Notch AM/FM off (default), 1 - Notch AM/FM on\n");
+    fprintf(stderr, "\t--agc <set point in dBfs>\t0 - Automatic Gain Control off (default),  set point in dBfs ( ex : -30 )\n");
 #endif
 	fprintf(stderr, "\nfile_options:\n");
 	fprintf(stderr, "\t--iq-file <input_file>\t\tRead I/Q samples from file\n");
@@ -255,7 +276,7 @@ int main(int argc, char **argv) {
 	int num_channels = 0;
 	enum input_types input = INPUT_UNDEF;
 	enum sample_formats sample_fmt = SFMT_UNDEF;
-#if WITH_RTLSDR || WITH_MIRISDR
+#if WITH_RTLSDR || WITH_MIRISDR || WITH_SDRPLAY
 	char *device = NULL;
 	float gain = SDR_AUTO_GAIN;
 	int correction = 0;
@@ -263,6 +284,12 @@ int main(int argc, char **argv) {
 #if WITH_MIRISDR
 	int mirisdr_hw_flavour = 0;
 	int mirisdr_usb_xfer_mode = 0;
+#endif
+#if WITH_SDRPLAY
+	char* sdrplay_antenna = "A";
+	int sdrplay_biast = 0;
+    int sdrplay_notch_filter = 0;
+    int sdrplay_agc = 0;
 #endif
 	int opt;
 	struct option long_opts[] = {
@@ -281,10 +308,17 @@ int main(int argc, char **argv) {
 		{ "hw-type",		required_argument,	NULL,	__OPT_HW_TYPE },
 		{ "usb-mode",		required_argument,	NULL,	__OPT_USB_MODE },
 #endif
+#if WITH_SDRPLAY
+		{ "sdrplay",		required_argument,	NULL,	__OPT_SDRPLAY },
+		{ "antenna",		required_argument,	NULL,	__OPT_ANTENNA },
+		{ "biast",		required_argument,	NULL,	__OPT_BIAST },
+        { "notch-filter",	required_argument,	NULL,	__OPT_NOTCH_FILTER },
+        { "agc",	required_argument,	NULL,	__OPT_AGC },
+#endif
 #if WITH_RTLSDR
 		{ "rtlsdr",		required_argument,	NULL,	__OPT_RTLSDR },
 #endif
-#if WITH_RTLSDR || WITH_MIRISDR
+#if WITH_RTLSDR || WITH_MIRISDR || WITH_SDRPLAY
 		{ "gain",		required_argument,	NULL,	__OPT_GAIN },
 		{ "correction",		required_argument,	NULL,	__OPT_CORRECTION },
 #endif
@@ -345,6 +379,25 @@ int main(int argc, char **argv) {
 			mirisdr_usb_xfer_mode = atoi(optarg);
 			break;
 #endif
+#if WITH_SDRPLAY
+		case __OPT_SDRPLAY:
+			device = optarg;
+			input = INPUT_SDRPLAY;
+			oversample = SDRPLAY_OVERSAMPLE; 
+			break;
+		case __OPT_ANTENNA:
+			sdrplay_antenna = strdup(optarg);
+			break;
+		case __OPT_BIAST:
+			sdrplay_biast = atoi(optarg);
+			break;
+		case __OPT_NOTCH_FILTER:
+			sdrplay_notch_filter = atoi(optarg);
+			break;
+		case __OPT_AGC:
+			sdrplay_agc = atoi(optarg);
+			break;
+#endif
 #if WITH_RTLSDR
 		case __OPT_RTLSDR:
 			device = optarg;
@@ -352,7 +405,7 @@ int main(int argc, char **argv) {
 			oversample = RTL_OVERSAMPLE;
 			break;
 #endif
-#if WITH_RTLSDR || WITH_MIRISDR
+#if WITH_RTLSDR || WITH_MIRISDR || WITH_SDRPLAY
 		case __OPT_GAIN:
 			gain = atof(optarg);
 			break;
@@ -469,6 +522,11 @@ int main(int argc, char **argv) {
 #if WITH_MIRISDR
 	case INPUT_MIRISDR:
 		mirisdr_init(&ctx, device, mirisdr_hw_flavour, centerfreq, gain, correction, mirisdr_usb_xfer_mode);
+		break;
+#endif
+#if WITH_SDRPLAY
+	case INPUT_SDRPLAY:
+		sdrplay_init(&ctx, device, sdrplay_antenna, centerfreq, gain, correction, sdrplay_biast, sdrplay_notch_filter, sdrplay_agc);
 		break;
 #endif
 	default:

--- a/dumpvdl2.h
+++ b/dumpvdl2.h
@@ -71,7 +71,7 @@
 #if WITH_RTLSDR
 #define __OPT_RTLSDR			11
 #endif
-#if WITH_MIRISDR || WITH_RTLSDR
+#if WITH_MIRISDR || WITH_RTLSDR || WITH_SDRPLAY
 #define __OPT_GAIN			12
 #define __OPT_CORRECTION		13
 #endif
@@ -81,6 +81,14 @@
 #define __OPT_MSG_FILTER		15
 #define __OPT_OUTPUT_ACARS_PP		16
 #define __OPT_UTC			17
+#ifdef WITH_SDRPLAY
+#define __OPT_SDRPLAY			80
+#define __OPT_ANTENNA			81
+#define __OPT_BIAST				82
+#define __OPT_NOTCH_FILTER		83
+#define __OPT_AGC				84
+#endif
+
 #define __OPT_HELP			99
 
 // message filters
@@ -139,6 +147,9 @@ enum input_types {
 #endif
 #if WITH_MIRISDR
 	INPUT_MIRISDR,
+#endif
+#if WITH_SDRPLAY
+	INPUT_SDRPLAY,
 #endif
 	INPUT_FILE,
 	INPUT_UNDEF

--- a/sdrplay.c
+++ b/sdrplay.c
@@ -1,0 +1,283 @@
+/*
+ *  dumpvdl2 - a VDL Mode 2 message decoder and protocol analyzer
+ *
+ *  Copyright (c) 2017 Fabrice Crohas <fcrohas@gmail.com> 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "sdrplay.h"
+#include "mirsdrapi-rsp.h"
+
+
+void sdrplay_init(vdl2_state_t *ctx, char *dev, char *antenna, uint32_t freq, float gain, int ppm_error, int enable_biast, int enable_notch_filter, int enable_agc) {
+    mir_sdr_ErrT err;
+    float ver;
+    struct sdrplay_t SDRPlay;
+    // Add ctx to local sdrplay context
+    SDRPlay.context = ctx;
+    /* initialize LNA State to 0 */
+    SDRPlay.lna_state = 0;    
+    /* Check API version */
+    err = mir_sdr_ApiVersion(&ver);
+    fprintf(stdout, "Using SDRPlay API version %f\n", ver);        
+    if ((err!= mir_sdr_Success) ||  (ver != MIR_SDR_API_VERSION)) {
+            fprintf(stderr, "Incorrect API version %f\n", ver);
+            _exit(1);
+    }       
+    /* Activate biast */
+    if (enable_biast) {
+        fprintf(stdout, "Bias-t activated\n");        
+	    err = mir_sdr_RSPII_BiasTControl(1);
+        if (err!= mir_sdr_Success) {
+            fprintf(stderr, "Unable to activate bias-t, error : %d\n", err);
+            _exit(1);
+        }
+    }
+    /* Activate antenna */
+    if (strcmp(antenna,"A") == 0) {
+    	err = mir_sdr_RSPII_AntennaControl(mir_sdr_RSPII_ANTENNA_A);
+    } else {
+    	err = mir_sdr_RSPII_AntennaControl(mir_sdr_RSPII_ANTENNA_B);
+    }
+    if (err!= mir_sdr_Success) {
+        fprintf(stderr, "Unable to select antenna %s, error : %d\n", antenna, err);
+        _exit(1);
+    }
+    fprintf(stdout, "Antenna %s activated\n", antenna);        
+    // Activate notch filter ?
+    if (enable_biast) {
+        fprintf(stdout, "Notch AM/FM filter activated\n");        
+        err = mir_sdr_RSPII_RfNotchEnable(1);
+        if (err!= mir_sdr_Success) {
+            fprintf(stderr, "Unable to activate notch filter, error : %d\n", err);
+            _exit(1);
+        }
+    }
+    /* DC Offset Mode */
+    err = mir_sdr_DCoffsetIQimbalanceControl(1,0);
+    if (err!= mir_sdr_Success) {
+        fprintf(stderr, "Unable to set DC and IQ correction, error : %d\n", err);
+        _exit(1);
+    }
+    /* Enable AGC control */
+    if (enable_agc!=0) {
+        err = mir_sdr_AgcControl(mir_sdr_AGC_100HZ, enable_agc,0,0,0,0,0);
+        if (err!= mir_sdr_Success) {
+            fprintf(stderr, "Unable to activate AGC with %d DbFs, error : %d\n", enable_agc, err);
+            _exit(1);
+        }
+        fprintf(stdout, "AGC activated with %d DbFs\n", enable_agc);
+    } else {
+        err = mir_sdr_AgcControl(mir_sdr_AGC_DISABLE, -30,0,0,0,0,0);
+        if (err!= mir_sdr_Success) {
+            fprintf(stderr, "Unable to desactivate AGC, error : %d\n", err);
+            _exit(1);
+        }
+    }
+    /* Frequency correction */
+    err = mir_sdr_SetPpm(ppm_error);
+    if (err!= mir_sdr_Success){
+       fprintf(stderr, "Unable to set PPM value to %d ppm, error %d\n",ppm_error, err);
+       _exit(1);
+    }  
+    fprintf(stdout, "Frequency correction set to %d ppm\n", ppm_error);
+    /* Allocate 8-bit interleaved I and Q buffers */
+    SDRPlay.sdrplay_data = XCALLOC(ASYNC_BUF_SIZE * ASYNC_BUF_NUMBER, sizeof(short));
+    ctx->sbuf = XCALLOC(ASYNC_BUF_SIZE / sizeof(uint16_t), sizeof(float));
+    int gRdBsystem = 39;
+    int gRdb = 0;
+    if (gain == MODES_AUTO_GAIN) {
+        SDRPlay.autogain = 1;
+        SDRPlay.lna_state = 3;
+        gRdb = 38;
+    } else {
+        // Gain setting is gain reduction
+        // Found correct setting using lna Gr table
+        int lnaGRdBs[9] = {0 , 10, 15, 21, 24, 34, 39, 45, 64};
+        // Start from position 0
+        if ((gain < 0) || (gain>104)) {
+            fprintf(stderr, "Wrong gain settings should be >0 or <104\n" );
+            _exit(1);
+        }
+        SDRPlay.lna_state = 0;
+        // So convert gain to gain reduction
+        gain = 124 - gain;
+        for (int i=0; i<= MAX_LNA_STATE; i++) {
+            // If selected gain reduction can be reach within current lnastate
+            if ((gain>= lnaGRdBs[i] + MIN_RSP_GAIN) && (gain <= lnaGRdBs[i] + MAX_RSP_GAIN)) {
+                gRdb = gain - lnaGRdBs[i];
+                SDRPlay.lna_state = i;
+                fprintf(stdout, "Selection gain reduction %d with LNA state %d\n", gRdb, SDRPlay.lna_state);
+                break;
+            }
+        }
+    }
+    // Initialize SDRPLAY ACC
+    SDRPlay.max_sig = MIN_GAIN_THRESH << ACC_SHIFT;
+    SDRPlay.max_sig_acc = MIN_GAIN_THRESH << ACC_SHIFT;
+    SDRPlay.data_index=0;
+    // Setup data stream
+    err = mir_sdr_StreamInit (&gRdb, (double)SDRPLAY_RATE/1e6, (double)freq/1e6, mir_sdr_BW_1_536, mir_sdr_IF_Zero, SDRPlay.lna_state, &gRdBsystem, mir_sdr_USE_RSP_SET_GR, &SDRPlay.sdrplaySamplesPerPacket,sdrplay_streamCallback,sdrplay_gainCallback,&SDRPlay);
+    if (err != mir_sdr_Success){
+            fprintf(stderr, "Unable to initialize RSP frequency : %.2f Mhz with sample rate %.2f, error : %d\n",(double)freq/1e6, (double)SDRPLAY_RATE/1e6, err);
+            _exit(1);
+    }
+    debug_print("Stream initialized with sdrplaySamplesPerPacket=%d gRdBsystem=%d\n", SDRPlay.sdrplaySamplesPerPacket, gRdBsystem);
+
+    /* Configure DC tracking in tuner */
+    err = mir_sdr_SetDcMode(4,0);
+    err |= mir_sdr_SetDcTrackTime(63);
+    if (err){
+            fprintf(stderr, "Set DC tracking failed, %d\n", err);
+            _exit(1);
+    }  
+
+    fprintf(stdout, "Device %s started\n", dev);
+    // Wait for exit
+    while(!do_exit) 
+    {
+        usleep(1000000);
+    } 
+}
+
+void sdrplay_cancel() {
+	mir_sdr_Uninit();
+}
+
+void sdrplay_streamCallback(short *xi, short *xq, unsigned int firstSampleNum,int grChanged, int rfChanged, int fsChanged, unsigned int numSamples, unsigned int reset,void *cbContext) {
+    int i, count1, count2, new_buf_flag;
+    unsigned int end, input_index;
+    struct sdrplay_t *SDRPlay = (struct sdrplay_t*)cbContext;
+    if (numSamples == 0) {
+        return;
+    }
+    // Think about what's going to happen, will we overrun end, will we fill a buffer?
+    /* count1 is lesser of input samples and samples to end of buffer */
+    /* count2 is the remainder, generally zero */
+    unsigned char *dptr = SDRPlay->sdrplay_data;
+    end = SDRPlay->data_index + (numSamples*2);
+    count2 = end - (ASYNC_BUF_SIZE * ASYNC_BUF_NUMBER);
+    if (count2 < 0) count2 = 0;                         /* count2 is samples wrapping around to start of buf */
+    count1 = (numSamples*2) - count2;   /* count1 is samples fitting before the end of buf */
+    /* flag is set if this packet takes us past a multiple of ASYNC_BUF_SIZE */
+
+    new_buf_flag = ((SDRPlay->data_index & (ASYNC_BUF_SIZE-1)) < (end & (ASYNC_BUF_SIZE-1)))? 0 : 1;
+
+    /* now interleave data from I/Q into circular buffer, and note max I value */
+
+    input_index = 0;
+    SDRPlay->max_sig = 0;
+
+    for (i = 0; i < count1 >> 1; i++)
+    {
+        // Copy I low / high part
+        dptr[SDRPlay->data_index] = xi[input_index] & 0xff;
+        SDRPlay->data_index++;
+        dptr[SDRPlay->data_index] = (xi[input_index] >> 8) & 0xff;
+        // Copy Q low / high part
+        SDRPlay->data_index++;        
+        dptr[SDRPlay->data_index] = xq[input_index] & 0xff;
+        SDRPlay->data_index++;
+        dptr[SDRPlay->data_index] = (xq[input_index] >> 8 ) & 0xff;
+        SDRPlay->data_index++;
+        if (xi[input_index] > SDRPlay->max_sig) SDRPlay->max_sig = xi[input_index];
+        input_index++;
+    }
+
+    /* apply slowly decaying filter to max signal value */
+
+    SDRPlay->max_sig -= 127;
+    SDRPlay->max_sig_acc += SDRPlay->max_sig;
+    SDRPlay->max_sig = SDRPlay->max_sig_acc >> ACC_SHIFT;
+    SDRPlay->max_sig_acc -= SDRPlay->max_sig;
+
+    /* this code is triggered as we reach the end of our circular buffer */
+    if (SDRPlay->data_index >= (ASYNC_BUF_SIZE * ASYNC_BUF_NUMBER))
+    {
+        SDRPlay->data_index = 0;  // pointer back to start of buffer */
+
+        /* adjust gain if automatically */
+        if (SDRPlay->autogain) { 
+            // Measure current gain
+            if (SDRPlay->max_sig > MAX_GAIN_THRESH) {
+                // If max gain reached for this LNA state
+                // Increase LNA state
+                if (SDRPlay->gRdB >= MAX_RSP_GAIN) {
+                    if (SDRPlay->lna_state<MAX_LNA_STATE) {
+                        SDRPlay->lna_state+=1;
+                        // move gain to min as we move on higher lna state attenuation
+                        // Absolute to force new gain
+                        mir_sdr_RSP_SetGr(MIN_RSP_GAIN, SDRPlay->lna_state, 1, 0);
+                    }
+                } else {
+                    mir_sdr_RSP_SetGr (1, SDRPlay->lna_state, 0, 0);
+                }
+            }
+            if (SDRPlay->max_sig < MIN_GAIN_THRESH) {
+                if (SDRPlay->gRdB <= MIN_RSP_GAIN) {
+                    // Only for positive LNA state
+                    if (SDRPlay->lna_state>0) {
+                        // Decrease LNA gain
+                        SDRPlay->lna_state-=1;
+                        // move gain to max as we move on lower lna state attenuation
+                        // Absolute to force new gain
+                        mir_sdr_RSP_SetGr(MAX_RSP_GAIN, SDRPlay->lna_state, 1, 0);
+                    }
+                } else {
+                    mir_sdr_RSP_SetGr (-1, SDRPlay->lna_state, 0, 0);
+                }
+            }
+        }
+    }
+
+    /* insert any remaining signal at start of buffer */
+
+    for (i = 0; i < count2 >> 1; i++)
+    {
+        // Copy I low / high part
+        dptr[SDRPlay->data_index] = xi[input_index] & 0xff;
+        SDRPlay->data_index++;
+        dptr[SDRPlay->data_index] = (xi[input_index] >> 8) & 0xff;
+        // Copy Q low / high part
+        SDRPlay->data_index++;        
+        dptr[SDRPlay->data_index] = xq[input_index] & 0xff;
+        SDRPlay->data_index++;
+        dptr[SDRPlay->data_index] = (xq[input_index] >> 8 ) & 0xff;
+        SDRPlay->data_index++;
+        input_index++;
+    }
+
+
+    /* send buffer downstream if enough available */
+
+    if (new_buf_flag)
+    {
+        /* go back by one buffer length, then round down further to start of buffer */
+        end = SDRPlay->data_index + ASYNC_BUF_SIZE * (ASYNC_BUF_NUMBER-1);
+        end &= ASYNC_BUF_SIZE * ASYNC_BUF_NUMBER - 1;
+        end &= ~(ASYNC_BUF_SIZE-1);
+        /* now pretend this came from an rtlsdr device */
+        process_buf_short(&SDRPlay->sdrplay_data[end], ASYNC_BUF_SIZE, SDRPlay->context);
+    }
+}
+
+void sdrplay_gainCallback(unsigned int gRdB,unsigned int lnaGRdB, void *cbContext) {
+    struct sdrplay_t *SDRPlay = (struct sdrplay_t*)cbContext;
+    SDRPlay->gRdB = gRdB;
+    debug_print("Gain callback event gRdb=%d lnaGRdB=%d \n", gRdB, lnaGRdB);
+}

--- a/sdrplay.h
+++ b/sdrplay.h
@@ -1,0 +1,56 @@
+/*
+ *  dumpvdl2 - a VDL Mode 2 message decoder and protocol analyzer
+ *
+ *  Copyright (c) 2017 Fabrice Crohas <fcrohas@gmail.com> 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdint.h>
+#include <signal.h>
+#include "dumpvdl2.h"
+#define ACC_SHIFT 14                    // sets time constant of averaging filter
+#define MIN_GAIN_THRESH 6               // increase gain if peaks below this 
+#define MAX_GAIN_THRESH 9               // decrease gain if peaks above this
+#define MAX_RSP_GAIN 59  					
+#define MIN_RSP_GAIN 20						// Not extended range so limit is 20
+#define MAX_LNA_STATE 8					// 8 according to RSP2 documentation for frf < 420 Mhz
+#define ASYNC_BUF_NUMBER     		16
+#define ASYNC_BUF_SIZE       		(16*16384)                // 256k
+#define MODES_AUTO_GAIN            -100                       // Use automatic gain 
+#define SDRPLAY_OVERSAMPLE 20
+#define SDRPLAY_RATE (SYMBOL_RATE * SPS * SDRPLAY_OVERSAMPLE)
+
+// exit flag sighandler
+extern int do_exit;
+// sdrplay struct
+struct sdrplay_t {
+	// SDRplay
+	int autogain;
+	int sdrplaySamplesPerPacket;
+	unsigned char *sdrplay_data;
+	int lna_state;
+	int gRdB;
+	int stop;
+    int max_sig; 
+    int max_sig_acc;
+    unsigned int data_index;    
+    void *context;
+};
+
+// sdrplay basic methods
+void sdrplay_init(vdl2_state_t *ctx, char *dev, char *antenna, uint32_t freq, float gain, int ppm_error, int enable_biast, int enable_notch_filter, int enable_agc);
+void sdrplay_cancel();
+void sdrplay_streamCallback(short *xi, short *xq, unsigned int firstSampleNum,int grChanged, int rfChanged, int fsChanged,unsigned int numSamples, unsigned int reset,void *cbContext);
+void sdrplay_gainCallback(unsigned int gRdB,unsigned int lnaGRdB, void *cbContext);
+


### PR DESCRIPTION
This is support to SDRPlay RSP 2.
  - Support of BIAS-T activation on antenna port B
  - Support of antenna port selection A or B
  - Support of native Notch AM/FM activation