### PR TITLE
Preliminary JSON format support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -256,6 +256,7 @@ add_library (dumpvdl2_base OBJECT
 	demod.c
 	dumpvdl2.c
 	esis.c
+	fmtr-json.c
 	fmtr-pp_acars.c
 	fmtr-text.c
 	gs_data.c

--- a/src/acars.c
+++ b/src/acars.c
@@ -142,18 +142,37 @@ la_vstring *acars_format_json(la_proto_node *tree) {
 	if(msg->err == true) {
 		return NULL;
 	}
+
 	char *txt = strdup(msg->txt);
-	// for(char *ptr = txt; *ptr != 0; ptr++) {
-	// 	if (*ptr == '\n' || *ptr == '\r') {
-	//    *ptr = ' ';
-	// 	}
-	// }
+	int newlen = 1;
+
+	for (char* p = txt; *p; p++)
+  	newlen += (*p == '\n' || *p == '\r') ? 2 : 1;
+
+	char *newtxt = malloc(newlen);
+
+	for (char *p = str, *q = newtxt;; p++) {
+    if (*p == '\n')
+    {
+			*q++ = '\\';
+			*q++ = 'n';
+    }
+		else if (*p == '\r')
+		{
+			*q++ = '\\';
+			*q++ = 'r';
+		}
+    else if (!(*q++ = *p))
+			break;
+	}
+
 	la_vstring *vstr = la_vstring_new();
 	la_vstring_append_sprintf(vstr,
 			"{ \"mode\": %1c, \"ident\": \"%7s\", \"ack\": \"%1c\", \"label\": \"%2s\", \"block_id\": \"%1c\", \"message_number\": \"%3s%c\", \"flight\": \"%6s\", \"text\": \"%s\" }",
 			msg->mode, msg->reg, msg->ack, msg->label, msg->block_id,
-			msg->msg_num, msg->msg_num_seq, msg->flight_id, txt);
+			msg->msg_num, msg->msg_num_seq, msg->flight_id, newtxt);
 
 	XFREE(txt);
+	XFREE(newtxt);
 	return vstr;
 }

--- a/src/acars.c
+++ b/src/acars.c
@@ -132,3 +132,28 @@ la_vstring *acars_format_pp(la_proto_node *tree) {
 	XFREE(txt);
 	return vstr;
 }
+
+la_vstring *acars_format_json(la_proto_node *tree) {
+	la_proto_node *acars_node = la_proto_tree_find_acars(tree);
+	if(acars_node == NULL) {
+		return NULL;
+	}
+	la_acars_msg *msg = acars_node->data;
+	if(msg->err == true) {
+		return NULL;
+	}
+	char *txt = strdup(msg->txt);
+	for(char *ptr = txt; *ptr != 0; ptr++) {
+		if (*ptr == '\n' || *ptr == '\r') {
+			*ptr = ' ';
+		}
+	}
+	la_vstring *vstr = la_vstring_new();
+	la_vstring_append_sprintf(vstr,
+			"{ \"mode\": %1c, \"ident\": \"%7s\", \"ack\": \"%1c\", \"label\": \"%2s\", \"block_id\": \"%1c\", \"message_number\": \"%3s%c\", \"flight\": \"%6s\", \"text\": \"%s\" }",
+			msg->mode, msg->reg, msg->ack, msg->label, msg->block_id,
+			msg->msg_num, msg->msg_num_seq, msg->flight_id, txt);
+
+	XFREE(txt);
+	return vstr;
+}

--- a/src/acars.c
+++ b/src/acars.c
@@ -143,11 +143,11 @@ la_vstring *acars_format_json(la_proto_node *tree) {
 		return NULL;
 	}
 	char *txt = strdup(msg->txt);
-	for(char *ptr = txt; *ptr != 0; ptr++) {
-		if (*ptr == '\n' || *ptr == '\r') {
-			*ptr = ' ';
-		}
-	}
+	// for(char *ptr = txt; *ptr != 0; ptr++) {
+	// 	if (*ptr == '\n' || *ptr == '\r') {
+	//    *ptr = ' ';
+	// 	}
+	// }
 	la_vstring *vstr = la_vstring_new();
 	la_vstring_append_sprintf(vstr,
 			"{ \"mode\": %1c, \"ident\": \"%7s\", \"ack\": \"%1c\", \"label\": \"%2s\", \"block_id\": \"%1c\", \"message_number\": \"%3s%c\", \"flight\": \"%6s\", \"text\": \"%s\" }",

--- a/src/acars.c
+++ b/src/acars.c
@@ -146,12 +146,12 @@ la_vstring *acars_format_json(la_proto_node *tree) {
 	char *txt = strdup(msg->txt);
 	int newlen = 1;
 
-	for (char* p = txt; *p; p++)
+	for (char *p = txt; *p; p++)
   	newlen += (*p == '\n' || *p == '\r') ? 2 : 1;
 
 	char *newtxt = malloc(newlen);
 
-	for (char *p = str, *q = newtxt;; p++) {
+	for (char *p = txt, *q = newtxt;; p++) {
     if (*p == '\n')
     {
 			*q++ = '\\';

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -56,8 +56,8 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
 	la_vstring *vstrAcars = acars_format_json(root);
 
 	la_vstring_append_sprintf(vstr,
-      "{ \"source_app\": \"dumpvdl2\", \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\", ",
-			timestamp->str, (float)metadata->freq / 1e+6, metadata->frame_pwr_dbfs, metadata->nf_pwr_dbfs,
+      "{ \"source_app\": \"dumpvdl2\", \"source_app_version\", \"%s\", \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\", ",
+			DUMPVDL2_VERSION, timestamp->str, (float)metadata->freq / 1e+6, metadata->frame_pwr_dbfs, metadata->nf_pwr_dbfs,
       metadata->ppm_error);
 	la_vstring_destroy(timestamp, true);
 

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -73,7 +73,7 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
 	EOL(vstr);
 
 	// vstr = la_proto_tree_format_text(vstr, root);
-	octet_string_t *ret = octet_string_new(vstr->str, vstr->len + 1);     // +1 for NULL terminator
+	octet_string_t *ret = octet_string_new(vstr->str, vstr->len);
 	la_vstring_destroy(vstr, false);
 	return ret;
 }

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -67,9 +67,13 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
 				metadata->synd_weight, metadata->datalen_octets, metadata->num_fec_corrections, metadata->idx);
 	}
 
-  la_vstring_append_sprintf(vstr,
-      "\"message\": %s }",
-      vstrAcars->str);
+	if(vstrAcars != NULL) {
+    la_vstring_append_sprintf(vstr,
+        "\"message\": %s",
+        vstrAcars->str);
+  }
+
+  la_vstring_append_sprintf(vstr, " }");
 
 	// vstr = la_proto_tree_format_text(vstr, root);
 	octet_string_t *ret = octet_string_new(vstr->str, vstr->len);

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -57,7 +57,7 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
 
 	la_vstring_append_sprintf(vstr,
       "{ \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\"",
-			DUMPVDL2_VERSION, timestamp->str, (float)metadata->freq / 1e+6, metadata->frame_pwr_dbfs, metadata->nf_pwr_dbfs,
+			timestamp->str, (float)metadata->freq / 1e+6, metadata->frame_pwr_dbfs, metadata->nf_pwr_dbfs,
       metadata->ppm_error);
 	la_vstring_destroy(timestamp, true);
 

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -72,7 +72,7 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
         "\"acars\": %s }",
         vstrAcars->str);
   } else {
-    la_vstring_append_sprintf(vstr, " } ");
+    la_vstring_append_sprintf(vstr, "%s", " }");
   }
 
 	// vstr = la_proto_tree_format_text(vstr, root);

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -73,7 +73,7 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
 	EOL(vstr);
 
 	// vstr = la_proto_tree_format_text(vstr, root);
-	octet_string_t *ret = octet_string_new(vstr->str, vstr->len);     // +1 for NULL terminator
+	octet_string_t *ret = octet_string_new(vstr->str, vstr->len + 1);     // +1 for NULL terminator
 	la_vstring_destroy(vstr, false);
 	return ret;
 }

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -1,0 +1,88 @@
+/*
+ *  dumpvdl2 - a VDL Mode 2 message decoder and protocol analyzer
+ *
+ *  Copyright (c) 2017-2020 Tomasz Lemiech <szpajder@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <math.h>                       // round
+#include <time.h>                       // strftime, gmtime, localtime
+#include <libacars/libacars.h>          // la_proto_node
+#include <libacars/vstring.h>           // la_vstring
+#include "fmtr-json.h"
+#include "output-common.h"              // fmtr_descriptor_t
+#include "dumpvdl2.h"                   // octet_string_t, Config
+#include "acars.h"                      // acars_format_pp
+
+static bool fmtr_json_supports_data_type(fmtr_input_type_t type) {
+	return(type == FMTR_INTYPE_DECODED_FRAME);
+}
+
+static la_vstring *format_timestamp(struct timeval const tv) {
+	struct tm *tmstruct = (Config.utc == true ? gmtime(&tv.tv_sec) : localtime(&tv.tv_sec));
+
+	char tbuf[30], tzbuf[8];
+	strftime(tbuf, sizeof(tbuf), "%F %T", tmstruct);
+	strftime(tzbuf, sizeof(tzbuf), "%Z", tmstruct);
+
+	la_vstring *vstr = la_vstring_new();
+	la_vstring_append_sprintf(vstr, "%s", tbuf);
+	if(Config.milliseconds == true) {
+		la_vstring_append_sprintf(vstr, ".%03d", (int)round(tv.tv_usec / 1000.0));
+	}
+	la_vstring_append_sprintf(vstr, " %s", tzbuf);
+	return vstr;
+}
+
+static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata, la_proto_node *root) {
+	ASSERT(metadata != NULL);
+	ASSERT(root != NULL);
+
+	la_vstring *timestamp = format_timestamp(metadata->burst_timestamp);
+	la_vstring *vstr = la_vstring_new();
+	la_vstring *vstrAcars = acars_format_json(root);
+
+	la_vstring_append_sprintf(vstr,
+      "{ \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\", ",
+			timestamp->str, (float)metadata->freq / 1e+6, metadata->frame_pwr_dbfs, metadata->nf_pwr_dbfs,
+      metadata->ppm_error);
+	la_vstring_destroy(timestamp, true);
+
+	if(Config.extended_header == true) {
+		la_vstring_append_sprintf(vstr,
+        "\"synd_weight\": %d, \"datalen_octets\": \"%u\", \"num_fec_corrections\": %d, \"idx\": \"%u\", ",
+				metadata->synd_weight, metadata->datalen_octets, metadata->num_fec_corrections, metadata->idx);
+	}
+
+  la_vstring_append_sprintf(vstr,
+      "\"message\": %s }",
+      vstrAcars);
+	EOL(vstr);
+
+	vstr = la_proto_tree_format_text(vstr, root);
+	octet_string_t *ret = octet_string_new(vstr->str, vstr->len);     // +1 for NULL terminator
+	la_vstring_destroy(vstr, false);
+	return ret;
+}
+
+fmtr_descriptor_t fmtr_DEF_json = {
+	.name = "json",
+	.description = "Transmittable computer-readable text",
+	.format_decoded_msg = fmtr_json_format_decoded_msg,
+	.format_raw_msg = NULL,
+	.supports_data_type = fmtr_json_supports_data_type,
+	.output_format = OFMT_TEXT,
+};

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -72,9 +72,8 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
         "\"acars\": %s }",
         vstrAcars->str);
   } else {
-    la_vstring_append_sprintf(vstr, " }");
+    la_vstring_append_sprintf(vstr, " } ");
   }
-
 
 	// vstr = la_proto_tree_format_text(vstr, root);
 	octet_string_t *ret = octet_string_new(vstr->str, vstr->len);

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -56,14 +56,14 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
 	la_vstring *vstrAcars = acars_format_json(root);
 
 	la_vstring_append_sprintf(vstr,
-      "{ \"source_app\": \"dumpvdl2\", \"source_app_version\", \"%s\", \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\" ",
+      "{ \"source_app\": \"dumpvdl2\", \"source_app_version\", \"%s\", \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\"",
 			DUMPVDL2_VERSION, timestamp->str, (float)metadata->freq / 1e+6, metadata->frame_pwr_dbfs, metadata->nf_pwr_dbfs,
       metadata->ppm_error);
 	la_vstring_destroy(timestamp, true);
 
 	if(Config.extended_header == true) {
 		la_vstring_append_sprintf(vstr,
-        ", \"synd_weight\": %d, \"datalen_octets\": \"%u\", \"num_fec_corrections\": %d, \"idx\": \"%u\", ",
+        ", \"synd_weight\": %d, \"datalen_octets\": \"%u\", \"num_fec_corrections\": %d, \"idx\": \"%u\"",
 				metadata->synd_weight, metadata->datalen_octets, metadata->num_fec_corrections, metadata->idx);
 	}
 

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -70,7 +70,6 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
   la_vstring_append_sprintf(vstr,
       "\"message\": %s }",
       vstrAcars->str);
-	EOL(vstr);
 
 	// vstr = la_proto_tree_format_text(vstr, root);
 	octet_string_t *ret = octet_string_new(vstr->str, vstr->len);

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -69,10 +69,10 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
 
   la_vstring_append_sprintf(vstr,
       "\"message\": %s }",
-      vstrAcars);
+      vstrAcars->str);
 	EOL(vstr);
 
-	vstr = la_proto_tree_format_text(vstr, root);
+	// vstr = la_proto_tree_format_text(vstr, root);
 	octet_string_t *ret = octet_string_new(vstr->str, vstr->len);     // +1 for NULL terminator
 	la_vstring_destroy(vstr, false);
 	return ret;

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -69,11 +69,12 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
 
 	if(vstrAcars != NULL) {
     la_vstring_append_sprintf(vstr,
-        "\"message\": %s",
+        "\"acars\": %s }",
         vstrAcars->str);
+  } else {
+    la_vstring_append_sprintf(vstr, " }");
   }
 
-  la_vstring_append_sprintf(vstr, " }");
 
 	// vstr = la_proto_tree_format_text(vstr, root);
 	octet_string_t *ret = octet_string_new(vstr->str, vstr->len);

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -76,7 +76,7 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
   }
 
 	// vstr = la_proto_tree_format_text(vstr, root);
-	octet_string_t *ret = octet_string_new(vstr->str, vstr->len);
+	octet_string_t *ret = octet_string_new(vstr->str, vstr->len + 1);
 	la_vstring_destroy(vstr, false);
 	return ret;
 }

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -35,8 +35,8 @@ static la_vstring *format_timestamp(struct timeval const tv) {
 	struct tm *tmstruct = (Config.utc == true ? gmtime(&tv.tv_sec) : localtime(&tv.tv_sec));
 
 	char tbuf[30], tzbuf[8];
-	strftime(tbuf, sizeof(tbuf), "%F %T", tmstruct);
-	strftime(tzbuf, sizeof(tzbuf), "%Z", tmstruct);
+	strftime(tbuf, sizeof(tbuf), "%FT%T", tmstruct);
+	strftime(tzbuf, sizeof(tzbuf), "-%z", tmstruct);
 
 	la_vstring *vstr = la_vstring_new();
 	la_vstring_append_sprintf(vstr, "%s", tbuf);
@@ -56,7 +56,7 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
 	la_vstring *vstrAcars = acars_format_json(root);
 
 	la_vstring_append_sprintf(vstr,
-      "{ \"source_app\": \"dumpvdl2\", \"source_app_version\", \"%s\", \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\"",
+      "{ \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\"",
 			DUMPVDL2_VERSION, timestamp->str, (float)metadata->freq / 1e+6, metadata->frame_pwr_dbfs, metadata->nf_pwr_dbfs,
       metadata->ppm_error);
 	la_vstring_destroy(timestamp, true);

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -56,20 +56,20 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
 	la_vstring *vstrAcars = acars_format_json(root);
 
 	la_vstring_append_sprintf(vstr,
-      "{ \"source_app\": \"dumpvdl2\", \"source_app_version\", \"%s\", \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\", ",
+      "{ \"source_app\": \"dumpvdl2\", \"source_app_version\", \"%s\", \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\" ",
 			DUMPVDL2_VERSION, timestamp->str, (float)metadata->freq / 1e+6, metadata->frame_pwr_dbfs, metadata->nf_pwr_dbfs,
       metadata->ppm_error);
 	la_vstring_destroy(timestamp, true);
 
 	if(Config.extended_header == true) {
 		la_vstring_append_sprintf(vstr,
-        "\"synd_weight\": %d, \"datalen_octets\": \"%u\", \"num_fec_corrections\": %d, \"idx\": \"%u\", ",
+        ", \"synd_weight\": %d, \"datalen_octets\": \"%u\", \"num_fec_corrections\": %d, \"idx\": \"%u\", ",
 				metadata->synd_weight, metadata->datalen_octets, metadata->num_fec_corrections, metadata->idx);
 	}
 
 	if(vstrAcars != NULL) {
     la_vstring_append_sprintf(vstr,
-        "\"acars\": %s }",
+        ", \"acars\": %s }",
         vstrAcars->str);
   } else {
     la_vstring_append_sprintf(vstr, "%s", " }");

--- a/src/fmtr-json.c
+++ b/src/fmtr-json.c
@@ -56,7 +56,7 @@ static octet_string_t *fmtr_json_format_decoded_msg(vdl2_msg_metadata *metadata,
 	la_vstring *vstrAcars = acars_format_json(root);
 
 	la_vstring_append_sprintf(vstr,
-      "{ \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\", ",
+      "{ \"source_app\": \"dumpvdl2\", \"timestamp\": \"%s\", \"frequency\": \"%.3f\", \"frame_pwr_dbfs\": \"%.1f\", \"nf_pwr_dbfs\": \"%.1f\", \"ppm_error\": \"%.1f\", ",
 			timestamp->str, (float)metadata->freq / 1e+6, metadata->frame_pwr_dbfs, metadata->nf_pwr_dbfs,
       metadata->ppm_error);
 	la_vstring_destroy(timestamp, true);

--- a/src/fmtr-json.h
+++ b/src/fmtr-json.h
@@ -1,5 +1,5 @@
 /*
- *  This file is a part of dumpvdl2
+ *  dumpvdl2 - a VDL Mode 2 message decoder and protocol analyzer
  *
  *  Copyright (c) 2017-2020 Tomasz Lemiech <szpajder@gmail.com>
  *
@@ -16,14 +16,11 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <stdint.h>
-#include <sys/time.h>               // struct timeval
-#include <libacars/libacars.h>      // la_proto_node
-#include <libacars/reassembly.h>    // la_reasm_ctx
-#include <libacars/vstring.h>       // la_vstring
 
-// acars.c
-la_proto_node *parse_acars(uint8_t *buf, uint32_t len, uint32_t *msg_type,
-		la_reasm_ctx *reasm_ctx, struct timeval rx_time);
-la_vstring *acars_format_pp(la_proto_node *tree);
-la_vstring *acars_format_json(la_proto_node *tree);
+#ifndef _FMTR_JSON_H
+#define _FMTR_JSON_H
+#include "output-common.h"              // fmtr_descriptor_t
+
+extern fmtr_descriptor_t fmtr_DEF_json;
+
+#endif // ! _FMTR_JSON_H

--- a/src/output-common.c
+++ b/src/output-common.c
@@ -23,6 +23,7 @@
 #include "dumpvdl2.h"           // NEW, ASSERT
 #include "output-common.h"
 
+#include "fmtr-json.h"          // fmtr_DEF_json
 #include "fmtr-text.h"          // fmtr_DEF_text
 #include "fmtr-pp_acars.h"      // fmtr_DEF_pp_acars
 #ifdef WITH_PROTOBUF_C
@@ -57,6 +58,7 @@ static dict const fmtr_intype_names[] = {
 };
 
 static dict const fmtr_descriptors[] = {
+	{ .id = OFMT_JSON,                  .val = &fmtr_DEF_json },
 	{ .id = OFMT_TEXT,                  .val = &fmtr_DEF_text },
 	{ .id = OFMT_PP_ACARS,              .val = &fmtr_DEF_pp_acars },
 #ifdef WITH_PROTOBUF_C

--- a/src/output-common.h
+++ b/src/output-common.h
@@ -54,7 +54,8 @@ typedef enum {
 	OFMT_UNKNOWN    = 0,
 	OFMT_TEXT       = 1,
 	OFMT_PP_ACARS   = 2,
-	OFMT_BINARY     = 3
+	OFMT_BINARY     = 3,
+	OFMT_JSON       = 4
 } output_format_t;
 
 typedef octet_string_t* (fmt_decoded_fun_t)(vdl2_msg_metadata *, la_proto_node *);

--- a/src/output-file.c
+++ b/src/output-file.c
@@ -43,7 +43,7 @@ typedef struct {
 } out_file_ctx_t;
 
 static bool out_file_supports_format(output_format_t format) {
-	return(format == OFMT_TEXT || format == OFMT_BINARY);
+	return(format == OFMT_TEXT || format == OFMT_JSON || format == OFMT_BINARY);
 }
 
 static void *out_file_configure(kvargs *kv) {
@@ -174,6 +174,16 @@ static void out_file_produce_text(out_file_ctx_t *self, vdl2_msg_metadata *metad
 	fflush(self->fh);
 }
 
+static void out_file_produce_json(out_file_ctx_t *self, vdl2_msg_metadata *metadata, octet_string_t *msg) {
+	ASSERT(msg != NULL);
+	ASSERT(self->fh != NULL);
+	UNUSED(metadata);
+	// Subtract 1 to cut off NULL terminator
+	fwrite(msg->buf, sizeof(uint8_t), msg->len - 1, self->fh);
+	fputc('\n', self->fh);
+	fflush(self->fh);
+}
+
 static void out_file_produce_binary(out_file_ctx_t *self, vdl2_msg_metadata *metadata, octet_string_t *msg) {
 	ASSERT(msg != NULL);
 	ASSERT(self->fh != NULL);
@@ -200,6 +210,8 @@ static int out_file_produce(void *selfptr, output_format_t format, vdl2_msg_meta
 	}
 	if(format == OFMT_TEXT) {
 		out_file_produce_text(self, metadata, msg);
+	} else if(format == OFMT_JSON) {
+		out_file_produce_json(self, metadata, msg);
 	} else if(format == OFMT_BINARY) {
 		out_file_produce_binary(self, metadata, msg);
 	}

--- a/src/output-file.c
+++ b/src/output-file.c
@@ -178,8 +178,7 @@ static void out_file_produce_json(out_file_ctx_t *self, vdl2_msg_metadata *metad
 	ASSERT(msg != NULL);
 	ASSERT(self->fh != NULL);
 	UNUSED(metadata);
-	// Subtract 1 to cut off NULL terminator
-	fwrite(msg->buf, sizeof(uint8_t), msg->len - 1, self->fh);
+	fwrite(msg->buf, sizeof(uint8_t), msg->len, self->fh);
 	fputc('\n', self->fh);
 	fflush(self->fh);
 }


### PR DESCRIPTION
This is a (mostly hacky) effort to implement JSON format support. So, similar to an effort I did a long while back (https://github.com/szpajder/dumpvdl2/issues/4) on the old dumpvdl2, I am adding JSON format so that users will be able to archive to file as well as send to remote server (such as https://app.airframes.io/about -- support still pending acceptance of this PR).

This initial implementation follows the implementations of the text and pp formats. The only things I don't love about this implementation:
* it is using a direct string append with the JSON format embedded in the string, rather than using a nice JSON library
* it doesn't yet output other ASN.1/AVLC details
* very little control over what is included in the JSON (should be able to include/exclude some levels of info)

But I think it's a start.

Example command:
```
dumpvdl2 --rtlsdr 0 --gain 40 136650000 136800000 136975000 \                                                                 
         --output decoded:text:file:path=/root/dumpvdl2.log \                                                                 
         --output decoded:json:file:path=/root/dumpvdl2.json \                                                                
         --output raw:binary:file:path=/root/dumpvdl2.raw \                                                                   
         --raw-frames --dump-asn1                                                                                             
```

Example output:
```
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:36:40 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-7.3", "nf_pwr_dbfs": "-27.1", "ppm_error": "4.4" }                                                   
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:37:02 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-6.2", "nf_pwr_dbfs": "-27.1", "ppm_error": "4.8", "acars": { "mode": 2, "ident": ".N8658A", "ack": "!
", "label": "37", "block_id": "1", "message_number": "M02A", "flight": "WN1648", "text": "05K6IC                              
NRO/AN.K3AC(DDADEBEA3V GBF (ATZDZBD)Z" } }                                                                                    
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:37:04 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-6.8", "nf_pwr_dbfs": "-27.0", "ppm_error": "4.6" }                                                   
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:37:39 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-8.5", "nf_pwr_dbfs": "-26.9", "ppm_error": "4.6" }                                                   
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:38:06 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-4.9", "nf_pwr_dbfs": "-26.9", "ppm_error": "4.3", "acars": { "mode": 2, "ident": ".N8658A", "ack": "E
", "label": "_d", "block_id": "3", "message_number": "S57A", "flight": "WN1648", "text": "" } }                               
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:38:10 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-2.2", "nf_pwr_dbfs": "-27.0", "ppm_error": "4.1", "acars": { "mode": 2, "ident": ".N8658A", "ack": "!
", "label": "H1", "block_id": "4", "message_number": "F83A", "flight": "WN1648", "text": "QXHADS2.ADS.N8658A030F071B7A054EF543
9CE3C40F2737" } }                                                                                                             
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:38:14 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-7.1", "nf_pwr_dbfs": "-27.2", "ppm_error": "4.3" }                                                   
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:38:36 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-4.9", "nf_pwr_dbfs": "-26.9", "ppm_error": "4.0", "acars": { "mode": 2, "ident": ".N8658A", "ack": "!
", "label": "H1", "block_id": "5", "message_number": "D25A", "flight": "WN1648", "text": "++76502,XXX,B737-800,200825,WN1648,K
SMF,KDEN,0502,SW2001                                                                                                          
6                                                                                                                             
N3838.0,W12118.8,250336,10750,009.0,177,018,CL,00000,0,                                                                       
N3838.0,W12116.5,250336,11096,008.0,182,018,CL,00000,0,                                                                       
N3838.1,W12114.0,250337,11415,0" } }                                                                                          
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:38:38 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-2.5", "nf_pwr_dbfs": "-26.7", "ppm_error": "4.0", "acars": { "mode": 2, "ident": ".N8658A", "ack": "!
", "label": "H1", "block_id": "6", "message_number": "D25B", "flight": "WN1648", "text": "++76502,XXX,B737-800,200825,WN1648,K
SMF,KDEN,0502,SW2001                                                                                                          
6                                                                                                                             
N3838.0,W12118.8,250336,10750,009.0,177,018,CL,00000,0,                                                                       
N3838.0,W12116.5,250336,11096,008.0,182,018,CL,00000,0,                                                                       
N3838.1,W12114.0,250337,11415,007.3,179,018,CL,00000,0,                                                                       
N3838.2,W12111.3,250337,12219,004.8,183,019,CL,00000,0,                                                                       
N3838.2,W12108.6,250337,13846,003.0,182,028,CL,00000,0,                                                                       
N3838.3,W12106.1,250338,15432,-01.3,174,032,CL,00000,0,                                                                       
:                                                                                                                             
" } }                                                                                                                         
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:38:40 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-2.9", "nf_pwr_dbfs": "-26.8", "ppm_error": "4.1" }                                                   
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:40:06 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-6.5", "nf_pwr_dbfs": "-27.0", "ppm_error": "3.5", "acars": { "mode": 2, "ident": ".N8658A", "ack": "F
", "label": "_d", "block_id": "7", "message_number": "S58A", "flight": "WN1648", "text": "" } }                               
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:40:09 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-6.5", "nf_pwr_dbfs": "-27.0", "ppm_error": "3.5", "acars": { "mode": 2, "ident": ".N8658A", "ack": "!
", "label": "H1", "block_id": "8", "message_number": "F84A", "flight": "WN1648", "text": "QXHADS2.ADS.N8658A0310071B8CFD505504
F3E5A00F7427" } }                                                                                                             
{ "source_app": "dumpvdl2", "source_app_version", "2.0.0-17a564a", "timestamp": "2020-08-24 20:40:11 PDT", "frequency": "136.9
75", "frame_pwr_dbfs": "-6.7", "nf_pwr_dbfs": "-27.2", "ppm_error": "3.5" }   
```