### PR TITLE
Log stats for all channels combined

### DIFF
--- a/src/dumpvdl2.c
+++ b/src/dumpvdl2.c
@@ -1023,6 +1023,7 @@ int main(int argc, char **argv) {
 			statsd_enabled = false;
 		} else {
 			if(input_is_iq) {
+				statsd_initialize_counters_combined_channels();
 				for(int i = 0; i < num_channels; i++) {
 					statsd_initialize_counters_per_channel(freqs[i]);
 				}

--- a/src/dumpvdl2.h
+++ b/src/dumpvdl2.h
@@ -392,6 +392,7 @@ int input_raw_frames_file_process(char const *file);
 // statsd.c
 #ifdef WITH_STATSD
 int statsd_initialize(char *statsd_addr);
+void statsd_initialize_counters_combined_channels();
 void statsd_initialize_counters_per_channel(uint32_t freq);
 void statsd_initialize_counters_per_msgdir();
 void statsd_initialize_counter_set(char **counter_set);


### PR DESCRIPTION
In addition to reporting per-channel stats (decoding successes and errors), this diff also creates the same counters as an aggregate of all channels.  This allows a single, non-frequency-specific monitoring stats set that always works (graphing-wise) even if the config adjusts frequencies from time to time.