### PR TITLE
Fix RTLSDR serial argument parsing

### DIFF
--- a/src/rtl.c
+++ b/src/rtl.c
@@ -72,6 +72,9 @@ static int rtl_verbose_device_search(char *s) {
 		}
 	}
 	fprintf(stderr, "\n");
+	/* does string look like an exact serial number */
+	if (strlen(s) == 8)
+		goto find_serial;
 	/* does string look like raw id number */
 	device = (int)strtol(s, &s2, 0);
 	if (s2[0] == '\0' && device >= 0 && device < device_count) {
@@ -79,6 +82,7 @@ static int rtl_verbose_device_search(char *s) {
 				device, rtlsdr_get_device_name((uint32_t)device));
 		return device;
 	}
+find_serial:
 	/* does string exact match a serial */
 	for (i = 0; i < device_count; i++) {
 		rtlsdr_get_device_usb_strings(i, vendor, product, serial);


### PR DESCRIPTION
Hi,

This PR addresses the following issue:

- First, the current way `--rtlsdr` parses its argument makes it impossible to disambiguate explicit serial numbers with low "value" (e.g. `00000001`, which is interpreted by the current code as `--rtlsdr 1` selecting device ID 1 instead of device with SN `00000001`). The proposed commit will always parse any 8-character-long argument as a serial, preserving existing behaviour for all other cases (non-8c-long arguments). There are other ways to rework this part of the code but I wanted to keep things as simple and as backward-compatible as possible.
- ~~Second, an additional commit is proposed to add signal stats reporting on good decoded messages via statsd (signal power, noise floor and ppm error). This is useful to keep track of the performance of the dongle and to check improvements due to antenna adjustments.~~

I hope this helps