### PR TITLE
fmtr-text: do not round up time

### DIFF
--- a/src/fmtr-text.c
+++ b/src/fmtr-text.c
@@ -33,11 +33,7 @@ static bool fmtr_text_supports_data_type(fmtr_input_type_t type) {
 static la_vstring *format_timestamp(struct timeval tv) {
 	int millis = 0;
 	if(Config.milliseconds == true) {
-		millis = round(tv.tv_usec / 1000.0);
-		if(millis > 999) {
-		    millis -= 1000;
-		    tv.tv_sec++;
-		}
+		millis = tv.tv_usec / 1000;
 	}
 	struct tm *tmstruct = (Config.utc == true ? gmtime(&tv.tv_sec) : localtime(&tv.tv_sec));
 


### PR DESCRIPTION
The current code rounds (up) milliseconds when dividing the system-provided microsecond time. Furthermore, if the result of the rounding exceeds 1000ms, it increments the system-provided seconds.

This is wrong as it effectively "pushes time forward", reporting a future time that is not passed at the time of the timestamp collection.

Time should never be rounded, time scale divisions should always be truncated to keep past, present and future in the right order.

This patch fixes this by removing the incorrect time adjustment. tv_usec is guaranteed to always be in the range [0, 999,999]. This also uses integer-based computation instead of (expensive) FP64.