### PR TITLE
Add statsd report for loud messages

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -366,6 +366,9 @@ void decode_vdl2_burst(vdl2_channel_t *v) {
 				goto cleanup;
 			}
 			statsd_timing_delta_per_channel(v->freq, "decoder.msg.processing_time", v->tstart);
+			if(v->frame_pwr > 1.0F) {	// check for log(v->frame_power) > 0dBFs
+				statsd_increment_per_channel(v->freq, "decoder.msg.good_loud");
+			}
 cleanup:
 			XFREE(data);
 			XFREE(fec);

--- a/src/statsd.c
+++ b/src/statsd.c
@@ -58,6 +58,7 @@ static char const *counters_per_channel[] = {
 	"decoder.errors.truncated_octets",
 	"decoder.errors.unstuff",
 	"decoder.msg.good",
+	"decoder.msg.good_loud",
 	"decoder.preambles.good",
 	"demod.sync.good",
 	NULL


### PR DESCRIPTION
Following up on #43 this adds a simple per-channel counter for (good) loud messages. A loud message is any message decoded above 0dBFS, to keep things simple.

HTH :)