### PR TITLE
add support for IF bandwidth filter setting to rtlsdr and soapysdr

### DIFF
--- a/src/rtl.c
+++ b/src/rtl.c
@@ -120,7 +120,7 @@ find_serial:
 	return -1;
 }
 
-void rtl_init(vdl2_state_t *ctx, char *dev, int freq, float gain, int correction, int bias) {
+void rtl_init(vdl2_state_t *ctx, char *dev, int freq, int bw, float gain, int correction, int bias) {
 	UNUSED(ctx);
 	int r;
 
@@ -148,6 +148,9 @@ void rtl_init(vdl2_state_t *ctx, char *dev, int freq, float gain, int correction
 		fprintf(stderr, "Failed to set freq correction for device #%d error %d\n", device, r);
 		_exit(1);
 	}
+	r = rtlsdr_set_tuner_bandwidth(rtl, bw);
+	if (r == 0)
+		fprintf(stderr, "Bandwidth set to %u Hz\n", bw);	// ignore failure
 
 	if(gain == SDR_AUTO_GAIN) {
 		r = rtlsdr_set_tuner_gain_mode(rtl, 0);

--- a/src/rtl.h
+++ b/src/rtl.h
@@ -24,5 +24,5 @@
 #define RTL_RATE (SYMBOL_RATE * SPS * RTL_OVERSAMPLE)
 
 // rtl.c
-void rtl_init(vdl2_state_t *ctx, char *dev, int freq, float gain, int correction, int bias);
+void rtl_init(vdl2_state_t *ctx, char *dev, int freq, int bw, float gain, int correction, int bias);
 void rtl_cancel();

--- a/src/soapysdr.c
+++ b/src/soapysdr.c
@@ -40,7 +40,7 @@ static void soapysdr_verbose_device_search() {
 	SoapySDRKwargsList_clear(results, length);
 }
 
-void soapysdr_init(vdl2_state_t *ctx, char *dev, char *antenna, int freq, float gain,
+void soapysdr_init(vdl2_state_t *ctx, char *dev, char *antenna, int freq, int bw, float gain,
 		int ppm_error, char* settings, char* gains_param) {
 	UNUSED(ctx);
 	soapysdr_verbose_device_search();
@@ -62,6 +62,8 @@ void soapysdr_init(vdl2_state_t *ctx, char *dev, char *antenna, int freq, float 
 		fprintf(stderr, "setFrequencyCorrection failed: %s\n", SoapySDRDevice_lastError());
 		_exit(1);
 	}
+	if(SoapySDRDevice_setBandwidth(sdr, SOAPY_SDR_RX, 0, bw) == 0)
+		fprintf(stderr, "Bandwidth set to %d Hz\n", bw);	// ignore error
 	if(SoapySDRDevice_hasDCOffsetMode(sdr, SOAPY_SDR_RX, 0)) {
 		if(SoapySDRDevice_setDCOffsetMode(sdr, SOAPY_SDR_RX, 0, true) != 0) {
 			fprintf(stderr, "setDCOffsetMode failed: %s\n", SoapySDRDevice_lastError());

--- a/src/soapysdr.h
+++ b/src/soapysdr.h
@@ -25,6 +25,6 @@
 #define SOAPYSDR_RATE (SYMBOL_RATE * SPS * SOAPYSDR_OVERSAMPLE)
 
 // soapysdr.c
-void soapysdr_init(vdl2_state_t *ctx, char *dev, char *antenna, int freq,
+void soapysdr_init(vdl2_state_t *ctx, char *dev, char *antenna, int freq, int bw,
 		float gain, int correction, char *settings, char *gains);
 void soapysdr_cancel();


### PR DESCRIPTION
Digging through rtlsdr source I stumbled upon this API (supported since 2016 in both rtlsdr and soapysdr) and traced it down to
https://lists.osmocom.org/pipermail/osmocom-sdr/2015-April/000043.html

The [video](https://www.youtube.com/watch?v=btDiWHuI730) from the [linked message](https://lists.osmocom.org/pipermail/osmocom-sdr/2015-February/000019.html) suggests it can improve SNR ratio by narrowing the default IF filter to reject unwanted signals even if they are within the sampling rate bandwidth, thereby avoiding/reducing ADC overload with strong unwanted adjacent signals.

My dumpvdl2 receivers are already in a rather quiet environment (i.e. in the middle of nowhere) so my testing doesn't show a significant improvement (although the error rate seems to be lower with this patch), but at least this suggests this patch "does no harm".

The selected bandwidth is hardware dependent, not all hardware supports it so failure to set bw is ignored. The target bw is set to max_freq - min_freq plus a margin of 2*SYMBOL_RATE (probably not that relevant given the filter roll off isn't likely to be very steep, but let's be cautious anyway).

I have added support for rtlsdr and soapysdr drivers since I am able to test those (and did so), I have not touched the other SDR inputs.

Further relevant info can be found [here](https://github.com/pothosware/SoapySDR/issues/100)

HTH