### PR TITLE
increase RTL_OVERSAMPLE from 10 to 12

### DIFF
--- a/src/rtl.h
+++ b/src/rtl.h
@@ -20,7 +20,7 @@
 #include "dumpvdl2.h"
 #define RTL_BUFSIZE 320000
 #define RTL_BUFCNT 15
-#define RTL_OVERSAMPLE 10
+#define RTL_OVERSAMPLE 12
 #define RTL_RATE (SYMBOL_RATE * SPS * RTL_OVERSAMPLE)
 
 // rtl.c


### PR DESCRIPTION
some locations have VDL2 messages on both 136.000 and 136.975 with oversample 10 the bandwidth is insufficient to cover both frequencies at the same time

increase the oversample a bit so it's possible to cover them